### PR TITLE
Removed 'en' in warframe.market api request.

### DIFF
--- a/WFInfo/Data.vb
+++ b/WFInfo/Data.vb
@@ -143,7 +143,7 @@ Class Data
             Return False
         End Try
         market_items = New Dictionary(Of String, String)()
-        For Each elem As JObject In m_i_temp("payload")("items")("en")
+        For Each elem As JObject In m_i_temp("payload")("items")
             Dim name As String = elem("item_name")
             If name.Contains("Prime ") Then
                 market_items(elem("id")) = name + "|" + elem("url_name").ToString()


### PR DESCRIPTION
Not sure if they changed their API - but their [doc ](https://docs.google.com/document/d/1121cjBNN4BeZdMBGil6Qbuqse-sWpEXPpitQH5fb_Fo/edit#)is still outdated.

Possibly due to the riven update today. --Either way, works without this. 