### PR TITLE
Line 146 in Data.vb fix for new warframe.market

### DIFF
--- a/WFInfo/Data.vb
+++ b/WFInfo/Data.vb
@@ -143,7 +143,7 @@ Class Data
             Return False
         End Try
         market_items = New Dictionary(Of String, String)()
-        For Each elem As JObject In m_i_temp("payload")("items")("en")
+        For Each elem As JObject In m_i_temp("payload")("items")
             Dim name As String = elem("item_name")
             If name.Contains("Prime ") Then
                 market_items(elem("id")) = name + "|" + elem("url_name").ToString()


### PR DESCRIPTION
As warframe.market API no longer associates with the Russians.
Not sure if they changed their API - but their doc is still outdated.

Possibly due to the riven update today. --Either way, works without this.

Fixes issue #4 

Someone will still need to build the new exe.